### PR TITLE
Remove capturing group

### DIFF
--- a/Source/UserAgentParser.php
+++ b/Source/UserAgentParser.php
@@ -30,7 +30,7 @@ function parse_user_agent( $u_agent = null ) {
 	if( preg_match('/\((.*?)\)/im', $u_agent, $parent_matches) ) {
 		preg_match_all('/(?P<platform>BB\d+;|Android|CrOS|Tizen|iPhone|iPad|iPod|Linux|(Open|Net|Free)BSD|Macintosh|Windows(\ Phone)?|Silk|linux-gnu|BlackBerry|PlayBook|X11|(New\ )?Nintendo\ (WiiU?|3?DS|Switch)|Xbox(\ One)?)
 				(?:\ [^;]*)?
-				(?:(;|,)|$)/imx', $parent_matches[1], $result, PREG_PATTERN_ORDER);
+				(?:;|,|$)/imx', $parent_matches[1], $result, PREG_PATTERN_ORDER);
 
 		$priority = array( 'Xbox One', 'Xbox', 'Windows Phone', 'Tizen', 'Android', 'FreeBSD', 'NetBSD', 'OpenBSD', 'CrOS', 'X11' );
 


### PR DESCRIPTION
Original author of the project you forked here. 

Not sure in what case you need comma, but the secondary capturing group isn't needed unless you intend to actually do something with said capture. The `(?:`…`)` is a non-capturing group specifically to avoid capturing. 